### PR TITLE
BUG: Use Curl and Doxygen binary mirror

### DIFF
--- a/scripts/dockcross-manylinux-download-cache.sh
+++ b/scripts/dockcross-manylinux-download-cache.sh
@@ -3,7 +3,7 @@
 # This module should be pulled and run from an ITKModule root directory to generate the Linux python wheels of this module,
 # it is used by the circle.yml file contained in ITKModuleTemplate: https://github.com/InsightSoftwareConsortium/ITKModuleTemplate
 
-wget -L https://data.kitware.com/api/v1/file/592dd8068d777f16d01e1a92/download -O zstd-1.2.0-linux.tar.gz
+curl https://data.kitware.com/api/v1/file/592dd8068d777f16d01e1a92/download -o zstd-1.2.0-linux.tar.gz
 gunzip -d zstd-1.2.0-linux.tar.gz
 tar xf zstd-1.2.0-linux.tar
 
@@ -12,7 +12,7 @@ curl -L https://github.com/InsightSoftwareConsortium/ITKPythonBuilds/releases/do
 tar xf ITKPythonBuilds-linux.tar
 
 mkdir tools
-wget -L http://ftp.stack.nl/pub/users/dimitri/doxygen-1.8.11.linux.bin.tar.gz -O doxygen-1.8.11.linux.bin.tar.gz
+curl https://data.kitware.com/api/v1/file/5c0aa4b18d777f2179dd0a71/download -o doxygen-1.8.11.linux.bin.tar.gz
 tar -xvzf doxygen-1.8.11.linux.bin.tar.gz -C tools
 
 curl -L https://github.com/KitwareMedical/VTKPythonBuilds/releases/download/${VTK_PACKAGE_VERSION:=v8.1.1}/VTKPythonBuilds-linux.tar.zst -O

--- a/scripts/windows-download-cache.ps1
+++ b/scripts/windows-download-cache.ps1
@@ -10,7 +10,7 @@ sz x ITKPythonBuilds-windows.zip -oC:\P -aoa -r
 if (-not (Test-Path env:VTK_PACKAGE_VERSION)) { $env:VTK_PACKAGE_VERSION = 'v8.1.1' }
 Invoke-WebRequest -Uri "https://github.com/KitwareMedical/VTKPythonBuilds/releases/download/$env:VTK_PACKAGE_VERSION/VTKPythonBuilds-windows.zip" -OutFile "VTKPythonBuilds-windows.zip"
 sz x VTKPythonBuilds-windows.zip -oC:\P -aoa -r
-Invoke-WebRequest -Uri "http://ftp.stack.nl/pub/users/dimitri/doxygen-1.8.11.windows.bin.zip" -OutFile "doxygen-1.8.11.windows.bin.zip"
+Invoke-WebRequest -Uri "https://data.kitware.com/api/v1/file/5c0ad59d8d777f2179dd3e9c/download" -OutFile "doxygen-1.8.11.windows.bin.zip"
 sz x doxygen-1.8.11.windows.bin.zip -oC:\P\doxygen -aoa -r
 Invoke-WebRequest -Uri "https://data.kitware.com/api/v1/file/5bbf87ba8d777f06b91f27d6/download/grep-win.zip" -OutFile "grep-win.zip"
 sz x grep-win.zip -oC:\P\grep -aoa -r


### PR DESCRIPTION
The Doxygen binary URL is no longer responsive.

curl on the manylinux images supports newer SSL required by
data.kitware.com.