### PR TITLE
WIP: ENH: ViewImage available as non-static class

### DIFF
--- a/include/itkViewImage.h
+++ b/include/itkViewImage.h
@@ -19,6 +19,10 @@
 #define itkViewImage_h
 #include <cstddef>
 #include <string>
+#include "vtkSmartPointer.h"
+#include "vtkImagePlaneWidget.h"
+#include "vtkRenderWindowInteractor.h"
+#include "itkFixedArray.h"
 namespace itk
 {
 
@@ -34,9 +38,20 @@ namespace itk
  * \ingroup ITKVtkGlue
  */
 template< typename TImage >
-class ViewImage
+class ViewImage : public ProcessObject
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(ViewImage);
+  /** Standard class aliases. */
+  using Self = ViewImage;
+  using Superclass = ProcessObject;
+  using Pointer = SmartPointer< Self >;
+
+  /** Method for creation through the object factory. */
+  itkNewMacro(Self);
+
+  /** Run-time type information (and related methods). */
+  itkTypeMacro(ViewImage, ProcessObject);
 
   using ImageType = TImage;
   /**
@@ -51,6 +66,48 @@ public:
       const std::string& windowTitle = "itkView",
       size_t windowWidth = 600,
       size_t windowHeight = 600);
+
+  /** Set/Get the image input of this viewer.  */
+  using Superclass::SetInput;
+  void SetInput(const ImageType *input);
+
+  const ImageType * GetInput();
+
+  const ImageType * GetInput(unsigned int idx);
+
+  /** Update. */
+  void Update() override;
+
+  /** \brief Shows the entire image.
+   *
+   * Updates the pipeline.
+   */
+  void UpdateLargestPossibleRegion() override;
+
+
+itkSetMacro(WindowWidth, size_t);
+itkGetMacro(WindowWidth, size_t);
+itkSetMacro(WindowHeight, size_t);
+itkGetMacro(WindowHeight, size_t);
+itkSetStringMacro(WindowTitle);
+itkGetStringMacro(WindowTitle);
+itkSetObjectMacro(RenderWindowInteractor, vtkRenderWindowInteractor);
+itkGetObjectMacro(RenderWindowInteractor, vtkRenderWindowInteractor);
+
+protected:
+  ViewImage();
+  ~ViewImage() override;
+  void PrintSelf(std::ostream & os, Indent indent) const ITK_OVERRIDE;
+
+  /** Does the real work. */
+  void GenerateData() override;
+
+private:
+size_t m_WindowWidth{600};
+size_t m_WindowHeight{600};
+std::string m_WindowTitle{"itkView"};
+vtkSmartPointer<vtkRenderWindowInteractor> m_RenderWindowInteractor;
+FixedArray< vtkSmartPointer< vtkImagePlaneWidget >, 3 > m_SlicePlanes;
 };
 }// namespace itk
 

--- a/include/itkvtkPython.h
+++ b/include/itkvtkPython.h
@@ -27,5 +27,6 @@
 #include "itkVTKImageExport.h"
 #include "itkVTKImageImport.h"
 #include "vtkImageData.h"
+#include "vtkRenderWindowInteractor.h"
 
 #include "vtkPythonUtil.h"

--- a/wrapping/VtkGlue.i
+++ b/wrapping/VtkGlue.i
@@ -20,7 +20,7 @@
 #include "itkVTKImageExport.h"
 #include "itkVTKImageImport.h"
 #include "vtkImageData.h"
-
+#include "vtkRenderWindowInteractor.h"
 %}
 
 
@@ -91,6 +91,12 @@ if os.name != 'nt':
 %typemap(in) vtkImageData* {
   $1 = NULL;
   $1 = (vtkImageData*) vtkPythonUtil::GetPointerFromObject ( $input, "vtkImageData" );
+  if ( $1 == NULL ) { SWIG_fail; }
+}
+
+%typemap(in) vtkRenderWindowInteractor* {
+  $1 = NULL;
+  $1 = (vtkRenderWindowInteractor*) vtkPythonUtil::GetPointerFromObject ( $input, "vtkRenderWindowInteractor" );
   if ( $1 == NULL ) { SWIG_fail; }
 }
 

--- a/wrapping/itkViewImage.wrap
+++ b/wrapping/itkViewImage.wrap
@@ -1,4 +1,5 @@
-itk_wrap_class("itk::ViewImage")
+itk_wrap_include("itkvtkPython.h")
+itk_wrap_class("itk::ViewImage" POINTER)
   UNIQUE(types "${WRAP_ITK_SCALAR}")
   UNIQUE(dims "2;3")
   foreach(d ${dims})


### PR DESCRIPTION
`ViewImage` class can be called using its static function `View` if
the user does not need to keep track of the `ViewImage` object.
However, in some case, the user needs to keep track of the object
and can now use the class through the typical ITK pointer interface.
Using this interface, the user has the extra option to set
the render window interactor.