### PR TITLE
COMP: Remove PUBLIC from target_link_libraries_with_dynamic_lookup

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -17,7 +17,7 @@ set(ITKVtkGlueTests
   )
 
 CreateTestDriver(ITKVtkGlue "${ITKVtkGlue-Test_LIBRARIES}" "${ITKVtkGlueTests}")
-target_link_libraries_with_dynamic_lookup(ITKVtkGlueTestDriver PUBLIC ${ITKVtkGlue_VTK_LIBRARIES})
+target_link_libraries_with_dynamic_lookup(ITKVtkGlueTestDriver ${ITKVtkGlue_VTK_LIBRARIES})
 
 itk_add_test(NAME itkVtkMedianImageFilterTest
   COMMAND ITKVtkGlueTestDriver


### PR DESCRIPTION
This causes `-lPUBLIC` with itk.js, and a build error.